### PR TITLE
Section layout admin column fix

### DIFF
--- a/includes/section-functions.php
+++ b/includes/section-functions.php
@@ -507,6 +507,11 @@ function add_column_data( $column, $post_id ) {
 		case 'layout':
 			$field = get_field_object( 'field_5d9239967f3ed' ); // section_layout key
 			$layout = get_field( 'section_layout', $post_id ) ?: 'default';
+			// For whatever reason the layout value is sometimes
+			// an array; handle that here:
+			if ( is_array( $layout ) ) {
+				$layout = $layout[0];
+			}
 			echo $field['choices'][$layout];
 			break;
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to FinAid-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/FinAid-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added fix for when a given section's layout value is an array instead of a string, causing illegal offset warnings when displaying the section's layout value in the "all sections" admin screen.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Warnings are bad

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
