### PR TITLE
Added faq breacrumb to topic pages

### DIFF
--- a/includes/breadcrumb-functions.php
+++ b/includes/breadcrumb-functions.php
@@ -132,6 +132,7 @@ function breadcrumb_links( $crumbs ) {
 	if ( is_array( $crumbs ) && count( $crumbs ) > 1 ) {
 		$current_crumb       = $crumbs[count( $crumbs ) - 1];
 		$current_post        = null;
+
 		if ( isset( $current_crumb['id'] ) ) {
 			// Prefix single FAQs with a link to a top-level FAQ
 			// page (at /faq/), if it exists:
@@ -151,6 +152,17 @@ function breadcrumb_links( $crumbs ) {
 				$current_crumb = array_pop( $crumbs );
 				array_push( $crumbs, $faq_crumb, $current_crumb );
 			}
+		} elseif ( is_array( $current_crumb ) && isset( $current_crumb['term'] ) && $current_crumb['term']->taxonomy === 'topic' ) {
+			$term         = $current_crumb['term'];
+			$faq_page     = get_page_by_path( 'faq' );
+			$faq_crumb    = array(
+				'text'       => $faq_page->post_title,
+				'url'        => get_permalink( $faq_page ),
+				'allow_html' => true
+			);
+
+			$current_crumb = array_pop( $crumbs );
+			array_push( $crumbs, $faq_crumb, $current_crumb );
 		}
 	}
 	return $crumbs;


### PR DESCRIPTION
<!---
Thank you for contributing to FinAid-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/FinAid-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the FAQ page to the breadcrumbs when on a topic archive page.

**Motivation and Context**
The topic archives should be treated as child pages of the main FAQ page, which lists all the topics.

**How Has This Been Tested?**
Change is available for review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
